### PR TITLE
Switch to using Allow All auth provider

### DIFF
--- a/ansible/hosts
+++ b/ansible/hosts
@@ -14,8 +14,8 @@ ansible_ssh_user=root
 product_type=openshift
 deployment_type=enterprise
 
-# uncomment the following to enable htpasswd authentication; defaults to DenyAllPasswordIdentityProvider
-#openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/openshift/openshift-passwd'}]
+# enable AllowAllPasswordIdentityProvider, as we don't need security for local developer environments. If we used the HTTP provider with user/pwds in a file, then that would be insecure by virtue of the hard coded user/pwds
+openshift_master_identity_providers=[{'name': 'allow_all_auth', 'login': 'true', 'challenge': 'true', 'kind': 'AllowAllPasswordIdentityProvider'}]
 
 # host group for masters
 [masters]


### PR DESCRIPTION
- Means that we don't need to provide a user file to enable access which would have hard coded user/pwd combinations, which wouldn't provide much security as they would be known
