### PR TITLE
Vagrant configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
    * ssh
 
 2. Download RHEL 7.1 Vagrant box for VirtualBox from https://access.redhat.com/downloads/content/293/ver=1/rhel---7/1.0.1/x86_64/product-downloads
-3. Donload the Red Hat Container Tools from  https://access.redhat.com/downloads/content/293/ver=1/rhel---7/1.0.1/x86_64/product-downloads
+3. Download the Red Hat Container Tools from  https://access.redhat.com/downloads/content/293/ver=1/rhel---7/1.0.1/x86_64/product-downloads
 4. Unzip the cdk.zip file you downloaded in your home directory. This should create ~/cdk (/Users/username/cdk)
- 
+
    ```
    $ cd
    $ unzip ~/Downloads/cdk-1.0-0.zip
-   ```   
+   ```
 5. Install additional Vagrant plugins for using Red Hat Vagrant boxes. The installation of the first plugin make take several minutes Vagrant may install some additional gem files as needed.
 
    ```
@@ -21,7 +21,7 @@
    $ vagrant plugin install vagrant-reload
    ```
    Verify the plugins are installed:
-   
+
    ```
    $ vagrant plugin list
    ```
@@ -31,7 +31,7 @@
    $ vagrant box add --name rhel-server-virtualbox-7.1-3 ~/Downloads/rhel-server-virutalbox-7.1-3.x86_64.box
    ```
    Verify that the boxes got installed:
-   
+
    ```
    $ vagrant box list
    ```
@@ -43,22 +43,22 @@
    ```
    (see https://github.com/mitchellh/vagrant/issues/5930)
 8. To register any box you run with Red Hat Subscription Manager, edit ~/.vagrant.d/Vagrantfile and add
-   
+
    ```
    Vagrant.configure('2') do |config|
      config.registration.username = 'rhn-support-pmuir'
      config.registration.password = ''
    end
    ```
-   Note you need to put your own username and password in here. 
+   Note you need to put your own username and password in here.
    Make sure you use a subscription which has an OpenShift Enterprise 3 entitlement. If you are an employee, use an employee subscription - the usernames will start with `rhn-`
 9. Run
-   
+
    ```
    vagrant up
    ```
 10. Once you've built the box you may want to export it
-   
+
    ```
    vagrant package
    ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,66 +1,103 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-Vagrant.configure('2') do |config|
-	# it is important that the name of this box is "default"
-	config.vbguest.auto_update = false
+$script_subscription_setup = <<SCRIPT
+# Attach subscriptions, enable repos, install packages
+# Fix this so we only attach one sub :-)
+subscription-manager list --installed | grep -q \"Red Hat OpenShift Enterprise\" || subscription-manager list --matches=\"*OpenShift Enterprise*\" --available --all --pool-only | subscription-manager attach --file=-
+subscription-manager repos --enable=\"rhel-7-server-rpms\" --enable=\"rhel-7-server-extras-rpms\" --enable=\"rhel-7-server-ose-3.0-rpms\"
+rpm -qa | grep -q epel-release || rpm -ivh http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum -y install wget git net-tools bind-utils iptables-services bridge-utils gcc python-virtualenv docker ansible && yum update -y && yum clean all
+SCRIPT
 
-	windows = (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
-    guest_additions = ENV['GUEST_ADDITIONS_PATH'] || (windows ? "C:\\Program files\\Oracle\\VirtualBox\\VBoxGuestAdditions.iso" :  "/usr/share/virtualbox/VBoxGuestAdditions.iso")
+$script_configure_docker = <<SCRIPT
+# Configure Docker
+grep -q \"insecure-registry 172.30.0.0/16\" /etc/sysconfig/docker || echo \"INSECURE_REGISTRY='--selinux-enabled --insecure-registry 172.30.0.0/16'\" | tee --append /etc/sysconfig/docker > /dev/null
+
+systemctl stop docker > /dev/null 2>&1 || :
+groupadd docker > /dev/null 2>&1 || :
+usermod -a -G docker vagrant
+systemctl enable docker && systemctl start docker
+chown root:docker /var/run/docker.sock
+systemctl enable docker && systemctl start docker
+SCRIPT
+
+$script_configure_openshift = <<SCRIPT
+# Configure ssh access for Ansible
+rm -f /root/.ssh/id_rsa /root/.ssh/id_rsa.pub /root/.ssh/known_hosts
+ssh-keygen -q -f /root/.ssh/id_rsa -N \"\" && cat  /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys && echo \"StrictHostKeyChecking=no\" >>  /root/.ssh/config && chmod 0600  /root/.ssh/authorized_keys  /root/.ssh/config && chown root:root /root/.ssh/*
+
+# Run Ansible
+rm -rf openshift-ansible && git clone https://github.com/openshift/openshift-ansible
+mkdir -p /etc/ansible && cp /home/vagrant/sync/ansible/hosts /etc/ansible
+ansible-playbook /home/vagrant/openshift-ansible/playbooks/byo/config.yml
+
+# Comment out the docker network options for openshift-sdn.
+# Not sure whether this is ok, but with these settings networking within the
+# docker containers does not work properly and network operations will time out
+# TODO - find out what the openshift-sdn does
+sed -e '/DOCKER_NETWORK_OPTIONS/ s/^#*/#/' -i /run/openshift-sdn/docker-network
+systemctl restart docker
+
+# Stop the systemctl controlled Openshift services
+# With these two services on the same machine, the master cannot find/detect
+# the node (needs investigation)
+# TODO - Investigate the problem with this approach
+systemctl stop openshift-master.service
+systemctl stop openshift-node.service
+
+# Start an all-in-one node
+# TODO - This should be made a proper shell or even systemctl script
+openshift start --cors-allowed-origins=.* --public-master=https://localhost:8443 --volume-dir=/tmp/oo &> openshift.log &
+
+# Give the server some time to come up
+sleep 10
+
+# Create the Openshift registry
+CREDENTIALS=/home/vagrant/openshift.local.config/master/openshift-registry.kubeconfig
+KUBECONFIG=/home/vagrant/openshift.local.config/master/admin.kubeconfig
+oadm registry --create --credentials=$CREDENTIALS --config=$KUBECONFIG
+
+# TODO - pre-load some more image streams, templates, etc.
+# Can be found in /home/vagrant/openshift-ansible/roles/openshift_examples/files/examples/
+# Use 'oc create -f'
+SCRIPT
+
+$script_cleanup = <<SCRIPT
+# Cleanup
+yum -y remove ansible
+yum -y autoremove && yum -y clean all
+SCRIPT
+
+Vagrant.configure('2') do |config|
+
+    config.vbguest.auto_update = false
 
 	config.vm.provider "virtualbox" do |v|
 		v.memory = 2048
 		v.cpus = 2
 		v.customize ["modifyvm", :id, "--natnet1", "172.12/16"]
-		v.customize ["storageattach", :id, "--storagectl", "IDE Controller", "--port", "1", "--device", "0", "--type", "dvddrive", "--medium", guest_additions]
 	end
 
-	# Box name
-	config.vm.hostname = 'openshift-enterprise-pmuir'
+	# Basic vm settings
+	config.vm.hostname = 'openshift-enterprise'
 	config.vm.box = "rhel-server-virtualbox-7.1-3"
 	config.vm.synced_folder '.', '/vagrant', disabled: true
 	config.nfs.functional = false
-	config.vm.network "private_network", ip: ENV['VM_IP'] || '10.0.2.15'
 
-	# Attach subscriptions, enable repos, install packages
-	# Fix this so we only attach one sub :-)
-	config.vm.provision 'shell', inline: "subscription-manager list --installed | grep -q \"Red Hat OpenShift Enterprise\" || subscription-manager list --matches=\"*OpenShift Enterprise*\" --available --all --pool-only | subscription-manager attach --file=-"
-	config.vm.provision 'shell', inline: "subscription-manager repos --enable=\"rhel-7-server-rpms\" --enable=\"rhel-7-server-extras-rpms\" --enable=\"rhel-7-server-ose-3.0-rpms\""
-	config.vm.provision 'shell', inline: "rpm -qa | grep -q epel-release || rpm -ivh http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
-	config.vm.provision 'shell', inline: "yum -y install wget git net-tools bind-utils iptables-services bridge-utils gcc python-virtualenv docker ansible && yum update -y && yum clean all"
+    # Configure networking. We will run the Openshift master so that it runs
+    # on localhost in the guest which in turn allows us to just forward
+    # Openshift relevant port
+    # TODO - check which ports we really need
+    config.vm.network "forwarded_port", guest: 80, host: 1080
+    config.vm.network "forwarded_port", guest: 443, host: 1443
+    config.vm.network "forwarded_port", guest: 5000, host: 5000
+    config.vm.network "forwarded_port", guest: 8080, host: 8080
+    config.vm.network "forwarded_port", guest: 8443, host: 8443
 
-	# Install Guest Additions
-	config.vm.provision 'shell', inline: "mkdir /mnt/cdrom && mount /dev/cdrom /mnt/cdrom"\
-	# We are expecting this to fail, as there is no XWindows on the VM
-	config.vm.provision 'shell', inline: "/mnt/cdrom/VBoxLinuxAdditions.run || true"
-	config.vm.provision 'shell', inline: "umount -f /mnt/cdrom && rm -rf /mnt/cdrom"
-	# Need to reboot to load Guest Additions
-	config.vm.provision :reload
-
-	# Configure Docker
-	config.vm.provision 'shell', inline: "grep -q \"insecure-registry 172.30.0.0/16\" /etc/sysconfig/docker || echo \"INSECURE_REGISTRY='--selinux-enabled --insecure-registry 172.30.0.0/16'\" | tee --append /etc/sysconfig/docker > /dev/null"
-
-	# Storage?
-
-	# Configure ssh access
-	config.vm.provision 'shell', inline: "rm -f /root/.ssh/id_rsa /root/.ssh/id_rsa.pub /root/.ssh/known_hosts"
-	config.vm.provision 'shell', inline: "ssh-keygen -q -f /root/.ssh/id_rsa -N \"\" && cat  /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys && echo \"StrictHostKeyChecking=no\" >>  /root/.ssh/config && chmod 0600  /root/.ssh/authorized_keys  /root/.ssh/config && chown root:root /root/.ssh/*"
-
-	config.vm.provision 'shell', inline: "systemctl stop docker > /dev/null 2>&1 || :" #in case this isn't first run
-	config.vm.provision 'shell', inline: "groupadd docker > /dev/null 2>&1 || : "
-	config.vm.provision 'shell', inline: "usermod -a -G docker vagrant"
-	config.vm.provision 'shell', inline: "systemctl enable docker && systemctl start docker"
-	config.vm.provision 'shell', inline: "chown root:docker /var/run/docker.sock"
-	config.vm.provision 'shell', inline: "systemctl enable docker && systemctl start docker"
-
-	# Run ansible
-	config.vm.provision 'shell', inline: "rm -rf openshift-ansible && git clone https://github.com/openshift/openshift-ansible"
-	config.vm.provision 'shell', inline: "mkdir -p /etc/ansible && cp /home/vagrant/sync/ansible/hosts /etc/ansible"
-	config.vm.provision 'shell', inline: "ansible-playbook /home/vagrant/openshift-ansible/playbooks/byo/config.yml"
-
-	# Uninstall Ansible
-	config.vm.provision 'shell', inline: "yum -y remove ansible"
-
-	# Cleanup
-	config.vm.provision 'shell', inline: "yum -y autoremove && yum -y clean all"
+    # Provision the vm by running some shell scripts
+    config.vm.provision "shell", inline: $script_subscription_setup
+    config.vm.provision "shell", inline: $script_configure_docker
+    config.vm.provision "shell", inline: $script_configure_openshift
+    config.vm.provision "shell", inline: $script_cleanup
 end


### PR DESCRIPTION
This works for me. Notice, that I went away again from the private network and use port forwarding. The trick seems to be `--public-master` when starting openshift.

Using this config I can bootstrap from scatch and for example run this:

```
oc new-app openshift/nodejs-010-centos7~https://github.com/openshift/nodejs-ex.git
```

and the app will actually properly build. 

I also cleaned up the Vagrantfile to split into multiple scripts.

Note, atm the Mac path for the guest additions is hard coded. This needs to be fixed.
